### PR TITLE
Add Let's Encrypt support and self-signed certificate fallback

### DIFF
--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -76,7 +76,7 @@ jobs:
         SERVER_PATH=$HOME/dikidi/$REPOSITORY_BASE_NAME
 
         docker compose -f $SERVER_PATH/docker-compose.yml down && docker rmi ${{ needs.build-and-push.outputs.docker_image_link }}
-        rm -rf $SERVER_PATH && mkdir -p $SERVER_PATH && cd $SERVER_PATH
+        find $SERVER_PATH -mindepth 1 -maxdepth 1 ! -name 'ssl' -exec rm -rf {} + && mkdir -p $SERVER_PATH && cd $SERVER_PATH
         curl -O https://raw.githubusercontent.com/$REPOSITORY_NAME_LOWER/${{ github.ref_name }}/deploy/docker-compose.yml
         sed -i "s|image: .*|image: ${{ needs.build-and-push.outputs.docker_image_link }}|" docker-compose.yml
         if [ -n "${{ vars.VITE_BACKEND_URL }}" ]; then

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     env_file:
       - .env
     volumes:
-      - ./ssl:/etc/nginx/ssl
+      - ./ssl/letsencrypt:/etc/letsencrypt
+      - ./ssl/self-signed:/etc/nginx/ssl/self-signed
+      - ./ssl/mycerts:/etc/nginx/ssl/mycerts
       - ./env-config.js:/usr/share/nginx/html/static/env-config.js
     ports:
       - 80:80
@@ -14,13 +16,12 @@ services:
     networks:
       - dikidi
     # environment:
-    #   - NGINX_SERVER_NAME=your_domain.com
-    #   - NGINX_INTERNAL_API_URL=http://localhost:8080/api
+    #   - NGINX_SERVER_NAME=localhost
+    #   - NGINX_INTERNAL_API_URL=http://backend:3000
     #   - NGINX_SECURE=false
     #   - NGINX_SSL_CERTIFICATE=/etc/nginx/ssl/nginx.crt
     #   - NGINX_SSL_CERTIFICATE_KEY=/etc/nginx/ssl/nginx.key
-    # volumes:
-    #   - ./ssl:/etc/nginx/ssl
+    #   - LETSENCRYPT_EMAIL=your_email@your_domain.com
 
 networks:
   dikidi:

--- a/dockerfile
+++ b/dockerfile
@@ -17,7 +17,7 @@ COPY deploy/nginx.conf.template /etc/nginx/templates/
 COPY deploy/generate_nginx_config.sh /usr/local/bin/
 COPY --from=build /app/dist /usr/share/nginx/html/
 
-RUN apt-get update && apt-get install -y gettext-base && apt-get clean
+RUN apt-get update && apt-get install -y gettext-base certbot && apt-get clean
 RUN chmod +x /usr/local/bin/generate_nginx_config.sh
 
 EXPOSE 80


### PR DESCRIPTION
- Integrated Certbot for automatic Let's Encrypt certificate generation and renewal.
- Added environment variable checks for Let's Encrypt email and server name.
- Implemented fallback to self-signed certificates if Let's Encrypt certificate generation fails.
- Updated Dockerfile to include Certbot installation.
- Modified generate_nginx_config.sh to handle SSL certificate generation and renewal logic.
- Updated docker-compose.yml to mount SSL directories
- Updated workflow to preserve the ssl directory