### PR TITLE
Update Nginx configuration to support Let's Encrypt

### DIFF
--- a/deploy/nginx.conf.template
+++ b/deploy/nginx.conf.template
@@ -13,6 +13,10 @@ server {
         proxy_pass __NGINX_INTERNAL_API_URL__;
     }
 
+    location /.well-known/acme-challenge/ {
+        root /usr/share/nginx/html;
+    }
+
     # Перенаправление на HTTPS, если secure: true
     __NGINX_REDIRECT_TO_HTTPS__
 }


### PR DESCRIPTION
- Added configuration to handle requests for Let's Encrypt verification.
- Ensured Nginx starts on port 80 for initial verification.
- Configured automatic reconfiguration and restart of Nginx with SSL after obtaining the certificate.